### PR TITLE
KeepAlive introduced

### DIFF
--- a/src/Atc.Opc.Ua/LoggingEventIdConstants.cs
+++ b/src/Atc.Opc.Ua/LoggingEventIdConstants.cs
@@ -32,4 +32,6 @@ internal static class LoggingEventIdConstants
 
     public const int SessionExecuteCommandRequest = 10060;
     public const int SessionExecuteCommandFailure = 10061;
+
+    public const int SessionKeepAliveRequestFailure = 10070;
 }

--- a/src/Atc.Opc.Ua/Services/OpcUaClientLoggerMessages.cs
+++ b/src/Atc.Opc.Ua/Services/OpcUaClientLoggerMessages.cs
@@ -152,4 +152,10 @@ public partial class OpcUaClient
         Level = LogLevel.Error,
         Message = "Executing method for parentNodeId '{parentNodeId}' and methodNodeId '{methodNodeId}' failed: '{errorMessage}'.")]
     private partial void LogSessionExecuteCommandFailure(string parentNodeId, string methodNodeId, string errorMessage);
+
+    [LoggerMessage(
+        EventId = LoggingEventIdConstants.SessionKeepAliveRequestFailure,
+        Level = LogLevel.Error,
+        Message = "KeepAlive request failed: ")]
+    private partial void LogSessionKeepAliveRequestFailure(Exception ex);
 }


### PR DESCRIPTION
A KeepAlive handler has been added. This checks at a fixed time interval (5s) whether the server is still available. If the server does not respond to the request, the session is disconnected.

Alternatively, a ReconnectHandler could also be installed here. This would try to reconnect to the server .